### PR TITLE
Update Discord message style and decouple insertion logic from logging and Discord messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 Zuap.log.*
 
+
 ### dotenv ###
 .env
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Created by https://www.toptal.com/developers/gitignore/api/intellij,macos,windows,dotenv
 # Edit at https://www.toptal.com/developers/gitignore?templates=intellij,macos,windows,dotenv
 
-Zuap.log.*
+Zuap.log*
 
 
 ### dotenv ###

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Created by https://www.toptal.com/developers/gitignore/api/intellij,macos,windows,dotenv
 # Edit at https://www.toptal.com/developers/gitignore?templates=intellij,macos,windows,dotenv
 
+Zuap.log.*
+
 ### dotenv ###
 .env
 

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -11,7 +11,7 @@
   <component name="PDMPlugin">
     <option name="skipTestSources" value="false" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="openjdk-18" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" project-jdk-name="18" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.15.2</version>
+            <version>1.15.3</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/src/main/java/de/infynyty/zuap/Zuap.java
+++ b/src/main/java/de/infynyty/zuap/Zuap.java
@@ -1,10 +1,5 @@
 package de.infynyty.zuap;
 
-import javax.security.auth.login.LoginException;
-
-import java.util.ArrayList;
-import java.util.concurrent.TimeUnit;
-
 import de.infynyty.zuap.insertion.Insertion;
 import de.infynyty.zuap.insertionHandler.InsertionHandler;
 import de.infynyty.zuap.insertionHandler.MeinWGZimmerHandler;
@@ -16,6 +11,10 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.TextChannel;
 import org.jetbrains.annotations.NotNull;
+
+import javax.security.auth.login.LoginException;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 
 @Log
 public class Zuap {
@@ -32,9 +31,9 @@ public class Zuap {
     }
 
     private static void parseWebsiteData(final JDA jda) {
-        handlers.add(new WOKOInsertionHandler(jda, dotenv, "WOKO: "));
-        handlers.add(new WGZimmerHandler(jda, dotenv, "WGZimmer: "));
-        handlers.add(new MeinWGZimmerHandler(jda, dotenv, "MeinWGZimmer: "));
+        handlers.add(new WOKOInsertionHandler(jda,"WOKO: "));
+        handlers.add(new WGZimmerHandler(jda, "WGZimmer: "));
+        handlers.add(new MeinWGZimmerHandler(jda, "MeinWGZimmer: "));
 
         handlers.forEach(handler -> new Thread(() -> {
             log.info("Started new thread for " + handler.getClass());

--- a/src/main/java/de/infynyty/zuap/Zuap.java
+++ b/src/main/java/de/infynyty/zuap/Zuap.java
@@ -13,8 +13,12 @@ import net.dv8tion.jda.api.entities.TextChannel;
 import org.jetbrains.annotations.NotNull;
 
 import javax.security.auth.login.LoginException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @Log
 public class Zuap {
@@ -25,16 +29,17 @@ public class Zuap {
 
     private final static ArrayList<InsertionHandler<? extends Insertion>> handlers = new ArrayList<>();
 
-    public static void main(String[] args) throws InterruptedException, LoginException {
+    public static void main(String[] args) throws InterruptedException, LoginException, IOException {
         final JDA jda = prepareDiscordBot();
         parseWebsiteData(jda);
     }
 
-    private static void parseWebsiteData(final JDA jda) {
+    private static void parseWebsiteData(final JDA jda) throws IOException {
         handlers.add(new WOKOInsertionHandler(jda,"WOKO: "));
         handlers.add(new WGZimmerHandler(jda, "WGZimmer: "));
         handlers.add(new MeinWGZimmerHandler(jda, "MeinWGZimmer: "));
 
+        log.addHandler(new FileHandler("Zuap.log", 100000, 3, true));
         handlers.forEach(handler -> new Thread(() -> {
             log.info("Started new thread for " + handler.getClass());
             while (true) {
@@ -71,5 +76,9 @@ public class Zuap {
 
     public static long getMainChannelId() {
         return Long.parseLong(dotenv.get("MAIN_CHANNEL_ID"));
+    }
+
+    public static void log(final Level level, final String message) {
+        log.log(level, message);
     }
 }

--- a/src/main/java/de/infynyty/zuap/Zuap.java
+++ b/src/main/java/de/infynyty/zuap/Zuap.java
@@ -7,9 +7,6 @@ import de.infynyty.zuap.insertionHandler.*;
 import io.github.cdimascio.dotenv.Dotenv;
 import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.JDABuilder;
-import net.dv8tion.jda.api.entities.TextChannel;
-import org.jetbrains.annotations.NotNull;
 
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
@@ -17,7 +14,6 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 @Log
 public class Zuap {

--- a/src/main/java/de/infynyty/zuap/discord/DiscordHandler.java
+++ b/src/main/java/de/infynyty/zuap/discord/DiscordHandler.java
@@ -1,0 +1,61 @@
+package de.infynyty.zuap.discord;
+
+import de.infynyty.zuap.Zuap;
+import de.infynyty.zuap.insertion.Insertion;
+import de.infynyty.zuap.insertionHandler.InsertionAnnouncer;
+import io.github.cdimascio.dotenv.Dotenv;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.entities.TextChannel;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.security.auth.login.LoginException;
+import java.util.logging.Level;
+
+@RequiredArgsConstructor
+public class DiscordHandler implements InsertionAnnouncer {
+
+
+    private final static Dotenv dotenv = Dotenv.load();
+
+    private final long mainChannelID;
+
+    @Nullable
+    private JDA jda;
+
+    @NotNull
+    public JDA prepareDiscordBot() throws InterruptedException, LoginException {
+        final JDA jda;
+        try {
+            jda = JDABuilder.createDefault(dotenv.get("TOKEN")).build();
+        } catch (LoginException e) {
+            Zuap.log(Level.SEVERE, "JDA login failed");
+            throw new LoginException("JDA login failed");
+        }
+        jda.awaitReady();
+        this.jda = jda;
+        Zuap.log(Level.INFO,"Bot online.");
+        return jda;
+    }
+
+    @Override
+    public void announce(@NotNull final Insertion insertion) {
+        if (jda == null) {
+            Zuap.log(Level.SEVERE, "Cannot display new insertion on Discord, because the JDA has not been initialized.");
+            return;
+        }
+        final TextChannel channel = jda.getChannelById(TextChannel.class, mainChannelID);
+        if (channel == null) {
+            Zuap.log(Level.SEVERE,"Cannot log to the Discord logging channel using the unknown channel id: " + mainChannelID);
+            return;
+        }
+        try {
+            channel.sendMessage(insertion.toMessage()).queue();
+        } catch (Exception ex) {
+            Zuap.log(Level.SEVERE, "Cannot display new insertion on Discord, because an error occurred while sending the message.");
+            Zuap.log(Level.SEVERE, ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/de/infynyty/zuap/discord/DiscordHandler.java
+++ b/src/main/java/de/infynyty/zuap/discord/DiscordHandler.java
@@ -14,17 +14,27 @@ import org.jetbrains.annotations.Nullable;
 import javax.security.auth.login.LoginException;
 import java.util.logging.Level;
 
+/**
+ * This class handles all logic regarding the Discord bot.
+ */
 @RequiredArgsConstructor
 public class DiscordHandler implements InsertionAnnouncer {
 
 
     private final static Dotenv dotenv = Dotenv.load();
 
+    /** The id of the channel that new insertions should be posted to. **/
     private final long mainChannelID;
 
     @Nullable
     private JDA jda;
 
+    /**
+     * Initializes the connection to the Discord bot.
+     * @return A JDA object to use for further Discord related activities.
+     * @throws InterruptedException
+     * @throws LoginException If the Discord API token is invalid.
+     */
     @NotNull
     public JDA prepareDiscordBot() throws InterruptedException, LoginException {
         final JDA jda;
@@ -40,6 +50,10 @@ public class DiscordHandler implements InsertionAnnouncer {
         return jda;
     }
 
+    /**
+     * Announces an insertion on the Discord server.
+     * @param insertion The insertion to announce, which must not be null.
+     */
     @Override
     public void announce(@NotNull final Insertion insertion) {
         if (jda == null) {

--- a/src/main/java/de/infynyty/zuap/discord/DiscordLoggingHandler.java
+++ b/src/main/java/de/infynyty/zuap/discord/DiscordLoggingHandler.java
@@ -1,17 +1,12 @@
 package de.infynyty.zuap.discord;
 
-import com.google.inject.Singleton;
-import de.infynyty.zuap.Zuap;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.Channel;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
 import java.util.logging.Handler;
-import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 /**

--- a/src/main/java/de/infynyty/zuap/discord/DiscordLoggingHandler.java
+++ b/src/main/java/de/infynyty/zuap/discord/DiscordLoggingHandler.java
@@ -14,6 +14,9 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
+/**
+ * A custom handler to log to a Discord server.
+ */
 @RequiredArgsConstructor
 public class DiscordLoggingHandler extends Handler {
     private final long logChannelID;

--- a/src/main/java/de/infynyty/zuap/discord/DiscordLoggingHandler.java
+++ b/src/main/java/de/infynyty/zuap/discord/DiscordLoggingHandler.java
@@ -1,0 +1,49 @@
+package de.infynyty.zuap.discord;
+
+import com.google.inject.Singleton;
+import de.infynyty.zuap.Zuap;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Channel;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+@RequiredArgsConstructor
+public class DiscordLoggingHandler extends Handler {
+    private final long logChannelID;
+    @NotNull
+    private final JDA jda;
+    @Override
+    public void publish(LogRecord record) {
+        final TextChannel channel = jda.getChannelById(TextChannel.class, logChannelID);
+        if (channel == null) {
+            System.err.println("Cannot log to the Discord logging channel using the unknown channel id: " + logChannelID);
+            return;
+        }
+        try {
+            channel.sendMessage(record.getMessage()).queue();
+        } catch (InsufficientPermissionException ex) {
+            System.err.println("Cannot log to the Discord channel with the id: " + logChannelID + " because of insufficient permissions");
+        } catch (IllegalArgumentException ex) {
+            System.err.println("Cannot log to the Discord channel with the id: " + logChannelID + " because of an incorrectly formatted message");
+        } catch (UnsupportedOperationException ex) {
+            System.err.println("Cannot log to the Discord channel with the id: " + logChannelID + " because of an unsupported action");
+        }
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void close() throws SecurityException {
+
+    }
+}

--- a/src/main/java/de/infynyty/zuap/insertion/Insertion.java
+++ b/src/main/java/de/infynyty/zuap/insertion/Insertion.java
@@ -1,15 +1,5 @@
 package de.infynyty.zuap.insertion;
 
-import java.awt.*;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URL;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 import lombok.Getter;
 import lombok.extern.java.Log;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -24,6 +14,16 @@ import org.jetbrains.annotations.Range;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsoup.nodes.Element;
+
+import java.awt.*;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /**
  * This class contains all information for an insertion on the  <a href="https://www.woko.ch">WOKO platform</a>.
@@ -171,7 +171,7 @@ public abstract class Insertion {
 
         MessageBuilder messageBuilder = new MessageBuilder();
         final Button linkButton = Button.link(String.valueOf(insertionURI), "Insertion Link");
-        final Button reportButton = Button.link("https://github.com/Infynyty/Zuap", "Report Issues");
+        final Button reportButton = Button.link("https://github.com/Infynyty/Zuap/issues", "Report Issues");
         final ActionRow actionRow = ActionRow.of(linkButton, reportButton);
 
         messageBuilder.setActionRows(actionRow);

--- a/src/main/java/de/infynyty/zuap/insertion/Insertion.java
+++ b/src/main/java/de/infynyty/zuap/insertion/Insertion.java
@@ -5,7 +5,6 @@ import lombok.extern.java.Log;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import org.jetbrains.annotations.NotNull;
@@ -18,7 +17,6 @@ import org.jsoup.nodes.Element;
 import java.awt.*;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -44,7 +42,7 @@ public abstract class Insertion {
     private JSONObject jsonObject;
 
     @NotNull
-    protected final URL insertionURI;
+    protected final URI insertionURI;
     @NotNull
     private final Date moveInDate;
     @Range(from = RENT_UNDEFINED, to = Integer.MAX_VALUE)
@@ -67,7 +65,7 @@ public abstract class Insertion {
     public Insertion(@NotNull final Element element) throws IllegalStateException {
         this.element = element;
         this.properties = setProperties();
-        this.insertionURI = setInsertionURL();
+        this.insertionURI = setInsertionURI();
         this.moveInDate = setMoveInDate();
 
         this.isNextTenantWanted = setIsNewTenantWanted();
@@ -87,7 +85,7 @@ public abstract class Insertion {
     public Insertion(@NotNull final JSONObject jsonObject) throws IllegalStateException {
         this.jsonObject = jsonObject;
         this.properties = setProperties();
-        this.insertionURI = setInsertionURL();
+        this.insertionURI = setInsertionURI();
         this.moveInDate = setMoveInDate();
 
         this.isNextTenantWanted = setIsNewTenantWanted();
@@ -97,7 +95,7 @@ public abstract class Insertion {
     }
 
     @NotNull
-    protected abstract URL setInsertionURL() throws IllegalStateException;
+    protected abstract URI setInsertionURI() throws IllegalStateException;
 
     protected abstract SortedMap<String, Optional<String>> setProperties();
 

--- a/src/main/java/de/infynyty/zuap/insertion/MeinWGZimmerInsertion.java
+++ b/src/main/java/de/infynyty/zuap/insertion/MeinWGZimmerInsertion.java
@@ -10,7 +10,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.util.*;
 
 @Log
 public class MeinWGZimmerInsertion extends Insertion {
@@ -30,6 +30,15 @@ public class MeinWGZimmerInsertion extends Insertion {
         } catch (NullPointerException | MalformedURLException e) {
             throw new IllegalStateException("URI to insertion could not be parsed.\n\n" + e.getMessage());
         }
+    }
+
+    @Override
+    protected SortedMap<String, Optional<String>> setProperties() {
+        SortedMap<String, Optional<String>> map = new TreeMap<>();
+        map.put("Rent", Optional.of(String.valueOf(setRent())));
+        map.put("Move-in Date", Optional.of(new SimpleDateFormat("dd.MM.yyyy").format(setMoveInDate())));
+        map.put("Next Tenant Wanted", Optional.of(setIsNewTenantWanted() ? "Yes" : "No"));
+        return map;
     }
 
     @Override

--- a/src/main/java/de/infynyty/zuap/insertion/MeinWGZimmerInsertion.java
+++ b/src/main/java/de/infynyty/zuap/insertion/MeinWGZimmerInsertion.java
@@ -6,11 +6,12 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
 import org.json.JSONObject;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+
 
 @Log
 public class MeinWGZimmerInsertion extends Insertion {
@@ -24,10 +25,10 @@ public class MeinWGZimmerInsertion extends Insertion {
     }
 
     @Override
-    protected @NotNull URL setInsertionURL() throws IllegalStateException {
+    protected @NotNull URI setInsertionURI() throws IllegalStateException {
         try {
-            return new URL(PROTOCOL + DOMAIN + "/zimmer/" + super.getJsonObject().get("RoomNr"));
-        } catch (NullPointerException | MalformedURLException e) {
+            return new URI(PROTOCOL + DOMAIN + "/zimmer/" + super.getJsonObject().get("RoomNr"));
+        } catch (NullPointerException | URISyntaxException e) {
             throw new IllegalStateException("URI to insertion could not be parsed.\n\n" + e.getMessage());
         }
     }

--- a/src/main/java/de/infynyty/zuap/insertion/WGZimmerInsertion.java
+++ b/src/main/java/de/infynyty/zuap/insertion/WGZimmerInsertion.java
@@ -10,6 +10,9 @@ import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 @Log
 public class WGZimmerInsertion extends Insertion {
@@ -30,6 +33,15 @@ public class WGZimmerInsertion extends Insertion {
         } catch (IndexOutOfBoundsException | MalformedURLException e) {
             throw new IllegalStateException("URI to insertion could not be parsed.\n\n" + e.getMessage());
         }
+    }
+
+    @Override
+    protected SortedMap<String, Optional<String>> setProperties() {
+        SortedMap<String, Optional<String>> map = new TreeMap<>();
+        map.put("Rent", Optional.of(String.valueOf(setRent())));
+        map.put("Move-in Date", Optional.of(new SimpleDateFormat("dd.MM.yyyy").format(setMoveInDate())));
+        map.put("Next Tenant Wanted", Optional.of(setIsNewTenantWanted() ? "Yes" : "No"));
+        return map;
     }
 
     @Override

--- a/src/main/java/de/infynyty/zuap/insertion/WGZimmerInsertion.java
+++ b/src/main/java/de/infynyty/zuap/insertion/WGZimmerInsertion.java
@@ -5,8 +5,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -27,10 +27,10 @@ public class WGZimmerInsertion extends Insertion {
 
 
     @Override
-    protected @NotNull URL setInsertionURL() throws IllegalStateException {
+    protected @NotNull URI setInsertionURI() throws IllegalStateException {
         try {
-            return new URL(PROTOCOL + DOMAIN + super.getElement().getElementsByTag("a").get(1).attr("href"));
-        } catch (IndexOutOfBoundsException | MalformedURLException e) {
+            return new URI(PROTOCOL + DOMAIN + super.getElement().getElementsByTag("a").get(1).attr("href"));
+        } catch (IndexOutOfBoundsException | URISyntaxException e) {
             throw new IllegalStateException("URI to insertion could not be parsed.\n\n" + e.getMessage());
         }
     }

--- a/src/main/java/de/infynyty/zuap/insertion/WOKOInsertion.java
+++ b/src/main/java/de/infynyty/zuap/insertion/WOKOInsertion.java
@@ -6,8 +6,8 @@ import org.jetbrains.annotations.Nullable;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -40,10 +40,10 @@ public class WOKOInsertion extends Insertion {
     }
 
     @Override
-    protected @NotNull URL setInsertionURL() {
+    protected @NotNull URI setInsertionURI() {
         try {
-            return new URL(PROTOCOL + DOMAIN + super.getElement().getElementsByTag("a").get(0).attr("href"));
-        } catch (IndexOutOfBoundsException | MalformedURLException e) {
+            return new URI(PROTOCOL + DOMAIN + super.getElement().getElementsByTag("a").get(0).attr("href"));
+        } catch (IndexOutOfBoundsException | URISyntaxException e) {
             throw new IllegalStateException("URI to insertion could not be parsed.\n\n" + e.getMessage());
         }
     }

--- a/src/main/java/de/infynyty/zuap/insertion/WOKOInsertion.java
+++ b/src/main/java/de/infynyty/zuap/insertion/WOKOInsertion.java
@@ -11,6 +11,9 @@ import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,6 +46,15 @@ public class WOKOInsertion extends Insertion {
         } catch (IndexOutOfBoundsException | MalformedURLException e) {
             throw new IllegalStateException("URI to insertion could not be parsed.\n\n" + e.getMessage());
         }
+    }
+
+    @Override
+    protected SortedMap<String, Optional<String>> setProperties() {
+        SortedMap<String, Optional<String>> map = new TreeMap<>();
+        map.put("Rent", Optional.of(String.valueOf(setRent())));
+        map.put("Move-in Date", Optional.of(new SimpleDateFormat("dd.MM.yyyy").format(setMoveInDate())));
+        map.put("Next Tenant Wanted", Optional.of(setIsNewTenantWanted() ? "Yes" : "No"));
+        return map;
     }
 
     //TODO: Use html parser instead of regex

--- a/src/main/java/de/infynyty/zuap/insertionHandler/InsertionAnnouncer.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/InsertionAnnouncer.java
@@ -3,6 +3,14 @@ package de.infynyty.zuap.insertionHandler;
 import de.infynyty.zuap.insertion.Insertion;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * This interface is used to announce a new insertion in any desired way to an arbitrary platform.
+ */
 public interface InsertionAnnouncer {
+
+    /**
+     * Announces an insertion.
+     * @param insertion The insertion to announce, which must not be null.
+     */
     void announce(@NotNull final Insertion insertion);
 }

--- a/src/main/java/de/infynyty/zuap/insertionHandler/InsertionAnnouncer.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/InsertionAnnouncer.java
@@ -1,0 +1,8 @@
+package de.infynyty.zuap.insertionHandler;
+
+import de.infynyty.zuap.insertion.Insertion;
+import org.jetbrains.annotations.NotNull;
+
+public interface InsertionAnnouncer {
+    void announce(@NotNull final Insertion insertion);
+}

--- a/src/main/java/de/infynyty/zuap/insertionHandler/InsertionHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/InsertionHandler.java
@@ -4,7 +4,6 @@ import de.infynyty.zuap.Zuap;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.JDA;
 import org.jetbrains.annotations.NotNull;
-import org.jsoup.HttpStatusException;
 
 import java.io.IOException;
 import java.sql.Date;
@@ -38,7 +37,7 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
      * @throws IOException
      * @throws InterruptedException
      */
-    protected abstract String pullUpdatedData() throws IOException, InterruptedException, HttpStatusException;
+    protected abstract String pullUpdatedData() throws IOException, InterruptedException;
 
     /**
      * Parses the entire data file, so that all insertions are read into {@link Insertion} objects.
@@ -66,7 +65,6 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
         }
         if (!isInitialized) {
             addInitialInsertions();
-            announcer.announce(currentInsertions.get(0));
             return;
         }
         addNewInsertions();

--- a/src/main/java/de/infynyty/zuap/insertionHandler/InsertionHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/InsertionHandler.java
@@ -1,21 +1,21 @@
 package de.infynyty.zuap.insertionHandler;
 
 import de.infynyty.zuap.Zuap;
-import lombok.extern.java.Log;
+import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import org.jetbrains.annotations.NotNull;
+import org.jsoup.HttpStatusException;
 
 import java.awt.*;
 import java.io.IOException;
 import java.sql.Date;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
+@RequiredArgsConstructor
 public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insertion.Insertion> {
 
     /**
@@ -26,40 +26,28 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
      * Used to compare updated insertions with locally saved info. Should be empty before updating local insertions.
      */
     private final ArrayList<Insertion> updatedInsertions = new ArrayList<>();
-
     @NotNull
     private final JDA jda;
     @NotNull
     private final String logPrefix;
-
-    /**
-     * Creates an insertion handler for a new website.
-     *
-     * @param jda        A reference to the discord bot.
-     * @param logPrefix
-     */
-    protected InsertionHandler(@NotNull final JDA jda, @NotNull final String logPrefix) {
-        this.jda = jda;
-        this.logPrefix = logPrefix;
-    }
+    @NotNull
+    private final InsertionAnnouncer announcer;
+    private boolean isInitialized = false;
 
     /**
      * Update the html data containing all insertions.
      *
      * @return The updated html.
-     *
      * @throws IOException
      * @throws InterruptedException
      */
-    protected abstract String pullUpdatedData() throws IOException, InterruptedException;
+    protected abstract String pullUpdatedData() throws IOException, InterruptedException, HttpStatusException;
 
     /**
      * Parses the entire data file, so that all insertions are read into {@link Insertion} objects.
      *
      * @param data The data containing all insertions.
-     *
      * @return A list containing all parsed insertions.
-     *
      * @throws IllegalStateException If the link to a given insertion cannot be parsed an exception is thrown because
      *                               the links are considered critical information for an {@link Insertion} object.
      */
@@ -68,74 +56,28 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
     /**
      * Updates the currently saved insertions. Online changes to insertions will be mirrored locally in
      * {@link InsertionHandler#currentInsertions}.
-     *
-     * @throws InterruptedException
      */
-    public void updateCurrentInsertions() throws InterruptedException {
+    public void updateCurrentInsertions() {
         //clear local list of updated insertions every time this method is called
         updatedInsertions.clear();
-        parseUpdatedInsertions();
-
-        if (currentInsertions.isEmpty()) {
-            final EmbedBuilder initalMessage = new EmbedBuilder();
-            initalMessage.setTitle("Loading...")
-                    .setColor(Color.ORANGE)
-                    .addField("Loading " + logPrefix + ".....................", " ", true)
-                    .addBlankField(true)
-                    .addField(":arrows_counterclockwise:", " ", false);
-            final EmbedBuilder updatedMessage = new EmbedBuilder();
-            updatedMessage.setTitle("Done")
-                    .setColor(Color.GREEN)
-                    .addField("Loading " + logPrefix + ".....................", " ", true)
-                    .addBlankField(true)
-                    .addField(":white_check_mark:", " ", false);
-            jda.getChannelById(TextChannel.class, Zuap.getLogChannelId()).sendMessageEmbeds(initalMessage.build()).queue(
-                    message -> {
-                        addInitialInsertions();
-                        message.editMessageEmbeds(updatedMessage.build()).queue();
-                    },
-                    message -> {
-                        updatedInsertions.clear();
-                        currentInsertions.clear();
-                        Zuap.log(Level.SEVERE, "Could not update loading message for discord. Initializing insertions anyway.");
-                        addInitialInsertions();
-                    }
-            );
+        try {
+            final String updatedData = pullUpdatedData();
+            updatedInsertions.addAll(getInsertionsFromData(updatedData));
+        } catch (IOException | InterruptedException | IllegalStateException e) {
+            Zuap.log(Level.SEVERE, "An exception occurred while trying to update the insertions. " + e.getMessage());
+            return;
+        }
+        if (!isInitialized) {
+            addInitialInsertions();
+            announcer.announce(currentInsertions.get(0));
             return;
         }
         addNewInsertions();
         removeDeletedInsertions();
-
-        logUpdates(
-            Level.INFO,
-            "Insertions updated at " + Date.from(Instant.now()) + ", numbers of insertions: " + updatedInsertions.size(),
-            Zuap.getLogChannelId()
+        Zuap.log(
+                Level.INFO,
+                "Insertions updated at " + Date.from(Instant.now()) + ", numbers of insertions: " + updatedInsertions.size()
         );
-    }
-
-    /**
-     * Logs any information on discord and using the Java Logger.
-     *
-     * @param level        The level of the information.
-     * @param logText      The message.
-     * @param logChannelId The discord channel that should be used to post this information.
-     */
-    private void logUpdates(final Level level, final String logText, final long logChannelId) {
-        Zuap.log(level, logPrefix + logText);
-        if (jda.getChannelById(TextChannel.class, logChannelId) == null) {
-            Zuap.log(Level.SEVERE, "Discord channel could not be found!");
-            return;
-        }
-        jda.getChannelById(TextChannel.class, logChannelId).sendMessage(logPrefix + logText).queue();
-    }
-
-    private void logUpdates(final Level level, final Insertion insertion, final long logChannelId) {
-        Zuap.log(level, logPrefix + "Found new insertion: " + insertion.toString());
-        if (jda.getChannelById(TextChannel.class, logChannelId) == null) {
-            Zuap.log(Level.SEVERE, "Discord channel could not be found!");
-            return;
-        }
-        jda.getChannelById(TextChannel.class, logChannelId).sendMessage(insertion.toMessage()).queue();
     }
 
     /**
@@ -145,10 +87,10 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
         // go through all current insertions and check that they are still in the updated insertions
         // remove them, if that isn't the case
         final boolean wasRemoved = currentInsertions.removeIf(
-            currentInsertion -> (!(updatedInsertions.contains(currentInsertion)))
+                currentInsertion -> (!(updatedInsertions.contains(currentInsertion)))
         );
         if (wasRemoved) {
-            logUpdates(Level.INFO, "One or more insertions were removed.", Zuap.getLogChannelId());
+            Zuap.log(Level.INFO, "One or more insertions were removed.");
         }
     }
 
@@ -159,11 +101,7 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
         for (final Insertion updatedInsertion : updatedInsertions) {
             if (!(currentInsertions.contains(updatedInsertion))) {
                 currentInsertions.add(updatedInsertion);
-                logUpdates(
-                    Level.INFO,
-                    updatedInsertion,
-                    Zuap.getMainChannelId()
-                );
+                announcer.announce(updatedInsertion);
             }
         }
     }
@@ -172,35 +110,8 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
      * Adds all insertions without checking for duplicates, if there are no insertions saved locally.
      */
     private void addInitialInsertions() {
-        // go through all new insertions and check whether they are contained in the current insertions
-        // update, if that isn't the case
+        isInitialized = true;
         currentInsertions.addAll(updatedInsertions);
         Zuap.log(Level.INFO, logPrefix + "Initial download of all insertions complete.");
-        logUpdates(
-                Level.INFO,
-                currentInsertions.get(0),
-                Zuap.getLogChannelId());
-    }
-
-    /**
-     * Tries to read all insertions from the updated html file. On failure retries happen automatically after
-     * {@link Zuap#UPDATE_DELAY_IN_MINS}.
-     *
-     * @throws InterruptedException
-     */
-    private void parseUpdatedInsertions() throws InterruptedException {
-        try {
-            updatedInsertions.addAll(getInsertionsFromData(pullUpdatedData()));
-        } catch (IOException | InterruptedException | IllegalStateException e) {
-            logUpdates(
-                Level.SEVERE,
-                "An exception occurred while trying to update the insertions. " +
-                    e.getMessage() +
-                    "Retrying in " + Zuap.UPDATE_DELAY_IN_MINS + " minutes.",
-                Zuap.getLogChannelId()
-            );
-            TimeUnit.MINUTES.sleep(Zuap.UPDATE_DELAY_IN_MINS);
-            parseUpdatedInsertions();
-        }
     }
 }

--- a/src/main/java/de/infynyty/zuap/insertionHandler/InsertionHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/InsertionHandler.java
@@ -2,13 +2,10 @@ package de.infynyty.zuap.insertionHandler;
 
 import de.infynyty.zuap.Zuap;
 import lombok.RequiredArgsConstructor;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.TextChannel;
 import org.jetbrains.annotations.NotNull;
 import org.jsoup.HttpStatusException;
 
-import java.awt.*;
 import java.io.IOException;
 import java.sql.Date;
 import java.time.Instant;
@@ -29,7 +26,7 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
     @NotNull
     private final JDA jda;
     @NotNull
-    private final String logPrefix;
+    private final String handlerName;
     @NotNull
     private final InsertionAnnouncer announcer;
     private boolean isInitialized = false;
@@ -64,7 +61,7 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
             final String updatedData = pullUpdatedData();
             updatedInsertions.addAll(getInsertionsFromData(updatedData));
         } catch (IOException | InterruptedException | IllegalStateException e) {
-            Zuap.log(Level.SEVERE, "An exception occurred while trying to update the insertions. " + e.getMessage());
+            Zuap.log(Level.SEVERE, handlerName, "An exception occurred while trying to update the insertions. " + e.getMessage());
             return;
         }
         if (!isInitialized) {
@@ -76,6 +73,7 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
         removeDeletedInsertions();
         Zuap.log(
                 Level.INFO,
+                handlerName,
                 "Insertions updated at " + Date.from(Instant.now()) + ", numbers of insertions: " + updatedInsertions.size()
         );
     }
@@ -90,7 +88,7 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
                 currentInsertion -> (!(updatedInsertions.contains(currentInsertion)))
         );
         if (wasRemoved) {
-            Zuap.log(Level.INFO, "One or more insertions were removed.");
+            Zuap.log(Level.INFO, handlerName, "One or more insertions were removed.");
         }
     }
 
@@ -112,6 +110,10 @@ public abstract class InsertionHandler<Insertion extends de.infynyty.zuap.insert
     private void addInitialInsertions() {
         isInitialized = true;
         currentInsertions.addAll(updatedInsertions);
-        Zuap.log(Level.INFO, logPrefix + "Initial download of all insertions complete.");
+        Zuap.log(Level.INFO, handlerName, "Initial download of all insertions complete.");
+    }
+
+    public @NotNull String getHandlerName() {
+        return handlerName;
     }
 }

--- a/src/main/java/de/infynyty/zuap/insertionHandler/MeinWGZimmerHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/MeinWGZimmerHandler.java
@@ -2,7 +2,6 @@ package de.infynyty.zuap.insertionHandler;
 
 import de.infynyty.zuap.Zuap;
 import de.infynyty.zuap.insertion.MeinWGZimmerInsertion;
-import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;

--- a/src/main/java/de/infynyty/zuap/insertionHandler/MeinWGZimmerHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/MeinWGZimmerHandler.java
@@ -1,5 +1,6 @@
 package de.infynyty.zuap.insertionHandler;
 
+import de.infynyty.zuap.Zuap;
 import de.infynyty.zuap.insertion.MeinWGZimmerInsertion;
 import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
@@ -13,8 +14,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
+import java.util.logging.Level;
 
-@Log
 public class MeinWGZimmerHandler extends InsertionHandler<MeinWGZimmerInsertion> {
 
 
@@ -56,7 +57,7 @@ public class MeinWGZimmerHandler extends InsertionHandler<MeinWGZimmerInsertion>
             try {
                 insertions.add(new MeinWGZimmerInsertion(rooms.getJSONObject(i)));
             } catch (IllegalStateException e) {
-                log.warning("Insertion could not be included because of a missing insertion URL!");
+                Zuap.log(Level.WARNING, getHandlerName(), "Insertion could not be included because of a missing insertion URL!");
             }
         }
         return insertions;

--- a/src/main/java/de/infynyty/zuap/insertionHandler/MeinWGZimmerHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/MeinWGZimmerHandler.java
@@ -16,17 +16,10 @@ import java.util.ArrayList;
 
 @Log
 public class MeinWGZimmerHandler extends InsertionHandler<MeinWGZimmerInsertion> {
-    /**
-     * Creates an insertion handler for a new website.
-     *
-     * @param jda       A reference to the discord bot.
-     * @param logPrefix
-     */
-    public MeinWGZimmerHandler(
-        final @NotNull JDA jda,
-        final @NotNull String logPrefix
-    ) {
-        super(jda, logPrefix);
+
+
+    public MeinWGZimmerHandler(@NotNull JDA jda, @NotNull String logPrefix, @NotNull InsertionAnnouncer announcer) {
+        super(jda, logPrefix, announcer);
     }
 
     @Override

--- a/src/main/java/de/infynyty/zuap/insertionHandler/MeinWGZimmerHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/MeinWGZimmerHandler.java
@@ -1,7 +1,6 @@
 package de.infynyty.zuap.insertionHandler;
 
 import de.infynyty.zuap.insertion.MeinWGZimmerInsertion;
-import io.github.cdimascio.dotenv.Dotenv;
 import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
 import org.jetbrains.annotations.NotNull;
@@ -21,15 +20,13 @@ public class MeinWGZimmerHandler extends InsertionHandler<MeinWGZimmerInsertion>
      * Creates an insertion handler for a new website.
      *
      * @param jda       A reference to the discord bot.
-     * @param dotenv    The file containing environment variables.
      * @param logPrefix
      */
     public MeinWGZimmerHandler(
         final @NotNull JDA jda,
-        final @NotNull Dotenv dotenv,
         final @NotNull String logPrefix
     ) {
-        super(jda, dotenv, logPrefix);
+        super(jda, logPrefix);
     }
 
     @Override

--- a/src/main/java/de/infynyty/zuap/insertionHandler/WGZimmerHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/WGZimmerHandler.java
@@ -44,7 +44,7 @@ public class WGZimmerHandler extends InsertionHandler<WGZimmerInsertion> {
 
         if (wgZimmerResponse.statusCode() >= 299) {
             throw new HttpStatusException(
-                    "Failed to update WGZimmer."
+                    "Failed to update WGZimmer"
                     , wgZimmerResponse.statusCode()
                     , wgZimmerRequest.uri().toString()
                     );

--- a/src/main/java/de/infynyty/zuap/insertionHandler/WGZimmerHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/WGZimmerHandler.java
@@ -2,7 +2,6 @@ package de.infynyty.zuap.insertionHandler;
 
 import de.infynyty.zuap.Zuap;
 import de.infynyty.zuap.insertion.WGZimmerInsertion;
-import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
 import org.jetbrains.annotations.NotNull;
 import org.jsoup.HttpStatusException;

--- a/src/main/java/de/infynyty/zuap/insertionHandler/WGZimmerHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/WGZimmerHandler.java
@@ -1,7 +1,6 @@
 package de.infynyty.zuap.insertionHandler;
 
 import de.infynyty.zuap.insertion.WGZimmerInsertion;
-import io.github.cdimascio.dotenv.Dotenv;
 import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
 import org.jsoup.Jsoup;
@@ -17,8 +16,8 @@ import java.util.ArrayList;
 
 @Log
 public class WGZimmerHandler extends InsertionHandler<WGZimmerInsertion> {
-    public WGZimmerHandler(final JDA jda, final Dotenv dotenv, final String logPrefix) {
-        super(jda, dotenv, logPrefix);
+    public WGZimmerHandler(final JDA jda, final String logPrefix) {
+        super(jda, logPrefix);
     }
 
     //TODO: Make it possible to change search variables

--- a/src/main/java/de/infynyty/zuap/insertionHandler/WGZimmerHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/WGZimmerHandler.java
@@ -4,7 +4,6 @@ import de.infynyty.zuap.Zuap;
 import de.infynyty.zuap.insertion.WGZimmerInsertion;
 import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
-import okhttp3.Response;
 import org.jetbrains.annotations.NotNull;
 import org.jsoup.HttpStatusException;
 import org.jsoup.Jsoup;
@@ -17,8 +16,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
+import java.util.logging.Level;
 
-@Log
 public class WGZimmerHandler extends InsertionHandler<WGZimmerInsertion> {
 
 
@@ -61,7 +60,7 @@ public class WGZimmerHandler extends InsertionHandler<WGZimmerInsertion> {
             try {
                 insertions.add(new WGZimmerInsertion(element));
             } catch (NumberFormatException e) {
-                log.warning("Insertion could not be included because of a missing insertion number!");
+                Zuap.log(Level.WARNING,getHandlerName(),"Insertion could not be included because of a missing insertion number!");
             }
         });
         return insertions;

--- a/src/main/java/de/infynyty/zuap/insertionHandler/WGZimmerHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/WGZimmerHandler.java
@@ -1,8 +1,12 @@
 package de.infynyty.zuap.insertionHandler;
 
+import de.infynyty.zuap.Zuap;
 import de.infynyty.zuap.insertion.WGZimmerInsertion;
 import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+import org.jsoup.HttpStatusException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
@@ -16,8 +20,10 @@ import java.util.ArrayList;
 
 @Log
 public class WGZimmerHandler extends InsertionHandler<WGZimmerInsertion> {
-    public WGZimmerHandler(final JDA jda, final String logPrefix) {
-        super(jda, logPrefix);
+
+
+    public WGZimmerHandler(@NotNull JDA jda, @NotNull String logPrefix, @NotNull InsertionAnnouncer announcer) {
+        super(jda, logPrefix, announcer);
     }
 
     //TODO: Make it possible to change search variables
@@ -36,7 +42,13 @@ public class WGZimmerHandler extends InsertionHandler<WGZimmerInsertion> {
         HttpResponse<String> wgZimmerResponse = wgZimmerClient.send(wgZimmerRequest,
             HttpResponse.BodyHandlers.ofString());
 
-
+        if (wgZimmerResponse.statusCode() >= 299) {
+            throw new HttpStatusException(
+                    "Failed to update WGZimmer."
+                    , wgZimmerResponse.statusCode()
+                    , wgZimmerRequest.uri().toString()
+                    );
+        }
         return wgZimmerResponse.body();
     }
 

--- a/src/main/java/de/infynyty/zuap/insertionHandler/WOKOInsertionHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/WOKOInsertionHandler.java
@@ -1,8 +1,10 @@
 package de.infynyty.zuap.insertionHandler;
 
 import de.infynyty.zuap.insertion.WOKOInsertion;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
+import org.jetbrains.annotations.NotNull;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
@@ -17,11 +19,9 @@ import java.util.ArrayList;
 @Log
 public class WOKOInsertionHandler extends InsertionHandler<WOKOInsertion> {
 
-    public WOKOInsertionHandler(
-        final JDA jda,
-        final String logPrefix
-    ) {
-        super(jda, logPrefix);
+
+    public WOKOInsertionHandler(@NotNull JDA jda, @NotNull String logPrefix, @NotNull InsertionAnnouncer announcer) {
+        super(jda, logPrefix, announcer);
     }
 
     @Override

--- a/src/main/java/de/infynyty/zuap/insertionHandler/WOKOInsertionHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/WOKOInsertionHandler.java
@@ -1,7 +1,6 @@
 package de.infynyty.zuap.insertionHandler;
 
 import de.infynyty.zuap.insertion.WOKOInsertion;
-import io.github.cdimascio.dotenv.Dotenv;
 import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
 import org.jsoup.Jsoup;
@@ -20,10 +19,9 @@ public class WOKOInsertionHandler extends InsertionHandler<WOKOInsertion> {
 
     public WOKOInsertionHandler(
         final JDA jda,
-        final Dotenv dotenv,
         final String logPrefix
     ) {
-        super(jda, dotenv, logPrefix);
+        super(jda, logPrefix);
     }
 
     @Override

--- a/src/main/java/de/infynyty/zuap/insertionHandler/WOKOInsertionHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/WOKOInsertionHandler.java
@@ -2,7 +2,6 @@ package de.infynyty.zuap.insertionHandler;
 
 import de.infynyty.zuap.Zuap;
 import de.infynyty.zuap.insertion.WOKOInsertion;
-import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
 import org.jetbrains.annotations.NotNull;
 import org.jsoup.Jsoup;

--- a/src/main/java/de/infynyty/zuap/insertionHandler/WOKOInsertionHandler.java
+++ b/src/main/java/de/infynyty/zuap/insertionHandler/WOKOInsertionHandler.java
@@ -1,7 +1,7 @@
 package de.infynyty.zuap.insertionHandler;
 
+import de.infynyty.zuap.Zuap;
 import de.infynyty.zuap.insertion.WOKOInsertion;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import net.dv8tion.jda.api.JDA;
 import org.jetbrains.annotations.NotNull;
@@ -15,8 +15,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
+import java.util.logging.Level;
 
-@Log
 public class WOKOInsertionHandler extends InsertionHandler<WOKOInsertion> {
 
 
@@ -25,7 +25,7 @@ public class WOKOInsertionHandler extends InsertionHandler<WOKOInsertion> {
     }
 
     @Override
-    protected String pullUpdatedData() throws InterruptedException, IOException {
+    protected String pullUpdatedData() throws IOException, InterruptedException {
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()
             .uri(URI.create("https://www.woko.ch/de/zimmer-in-zuerich"))
@@ -46,7 +46,7 @@ public class WOKOInsertionHandler extends InsertionHandler<WOKOInsertion> {
             try {
                 insertions.add(new WOKOInsertion(element));
             } catch (IllegalStateException e) {
-            log.warning("Insertion could not be included because of a missing insertion URL!");
+                Zuap.log(Level.WARNING, getHandlerName(),"Insertion could not be included because of a missing insertion URL!");
             }
         });
         return insertions;


### PR DESCRIPTION
This pull request will update the Discord messages to look a lot nicer. Furthermore a lot of the insertion handling logic was previously tightly coupled to the logging and Discord messages. Now these three aspects are separated.
This also fixes issue #1 , but only in the sense that there is no initial download loop anymore. Wgzimmer.ch can still no longer be parsed by the bot.